### PR TITLE
Enable building as subproject of another CMake project

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -33,9 +33,9 @@ set(MURISCVNN_LIB "muriscvnn")
 
 add_library(${MURISCVNN_LIB} STATIC)
 
-target_include_directories(
-  ${MURISCVNN_LIB} PUBLIC ${PROJECT_SOURCE_DIR}/Include ${PROJECT_SOURCE_DIR}/Include/CMSIS/NN/Include
-)
+target_include_directories(${MURISCVNN_LIB} PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/../Include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../Include/CMSIS/NN/Include)
 
 if(SIMULATOR)
   # TODO(fabianpedd): We currently need to include the Vicuna headers in order to redirect printf


### PR DESCRIPTION
Remove PROJECT_SOURCE_DIR in favor of CMAKE_CURRENT_SOURCE_DIR. This is necessary when including the project in another cmake project, since otherwise the path to the muriscv-nn includes is incorrect.